### PR TITLE
have a flag to NOT do masking of zero counts.

### DIFF
--- a/examples/bin/node.sh
+++ b/examples/bin/node.sh
@@ -22,7 +22,8 @@ shift
 command=$1
 
 #to mask a Count metric/aggregator for datasource 'a', u need to specify 2metrics in the list 'a.count' & 'a.special_count_metric'
-MASKING_OPTS="-DDATASPARK_DO_MASKING=true -DDATASPARK_EXTRAPOLATION_FACTOR=1.35 -DDATASPARK_PRIVACY_THRESHOLD=200 -DDATASPARK_MASKED_METRICS=data.uniq,data.special_count_metric,data.sum,data.count,data2.latencyMs,data2.uniq,data2.special_count_metric,data2.sum,data2.count"
+#masking zero counts can happen only if the flag 'DATASPARK_DO_MASKING' is set to true first, i.e. flag 'DATASPARK_DO_MASKING' takes precedence.
+MASKING_OPTS="-DMASK_ZERO_COUNTS=false -DDATASPARK_DO_MASKING=true -DDATASPARK_EXTRAPOLATION_FACTOR=1.35 -DDATASPARK_PRIVACY_THRESHOLD=200 -DDATASPARK_MASKED_METRICS=data.uniq,data.special_count_metric,data.sum,data.count,data2.latencyMs,data2.uniq,data2.special_count_metric,data2.sum,data2.count"
 
 LIB_DIR="${DRUID_LIB_DIR:=lib}"
 CONF_DIR="${DRUID_CONF_DIR:=conf/druid}"


### PR DESCRIPTION
 i.e. report 0 humans as 0 humans, 0 trips as 0 instead of applying privacy/extrapolation